### PR TITLE
Pillow now needs libjpeg-devel to be installed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN yum update -y
 RUN yum install -y wget httpd python-setuptools python-pip python-devel \
                    libxslt-devel libxml2-devel zlib-devel libffi-devel \
                    openssl-devel libpqxx-devel libyaml-devel gcc \
-                   postgresql-devel python-virtualenv
+                   postgresql-devel python-virtualenv libjpeg-devel
 
 RUN virtualenv /www/sentry/
 RUN source /www/sentry/bin/activate


### PR DESCRIPTION
See https://github.com/python-pillow/Pillow/issues/1457 and http://stackoverflow.com/questions/34631806/fail-during-installation-of-pillow-python-module-in-linux/34631976
